### PR TITLE
Corrected k-means++ algorithm.

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,5 @@
 {
-    "spellright.language": "",
+    "spellright.language": "en",
     "spellright.documentTypes": [
         "markdown",
         "latex",

--- a/kmeans/src/clust.h
+++ b/kmeans/src/clust.h
@@ -6,6 +6,8 @@
 #include <fstream> // std::ifstream
 #include <cmath>   // pow, sqrt, log, isnan
 #include <limits>  // std::numeric_limits<float>::quiet_NaN();
+#include <cassert>
+#include <random>
 
 class Sample
 {

--- a/kmeans/src/kmeans.cpp
+++ b/kmeans/src/kmeans.cpp
@@ -5,7 +5,6 @@
  * Author: Yi Zhou
 */
 #include <cstdio> // printf
-#include <random>
 #include "clust.h"
 using namespace std;
 const static size_t MAX_ITER = 1000, ITER_EACH = 100;
@@ -38,6 +37,7 @@ int main(int argc, char **argv)
     {
         samples.emplace_back(matrix[i], i);
     }
+    assert(samples.size() > 0);
     uniform_int_distribution<size_t> range(0, samples.size() - 1);
 
     // Normalize data before clustering -> mean=0 and standard deviation=1 on each column
@@ -66,8 +66,7 @@ int main(int argc, char **argv)
             vector<Cluster> clusters;
             clusters.emplace_back(1);
             clusters[0].add_sample(samples[range(seed)]);
-            // find the point that's the furthest from the last centroid and
-            // assign it as the next centroid
+            // k-means++ (https://en.wikipedia.org/wiki/K-means%2B%2B)
             kmeans::initialize_clusters(clusters, samples, k);
 
             size_t iter_num = 0,


### PR DESCRIPTION
Fixes issue #7. Improvements were minimal on the sample datasets, and the runtime was a lot longer.

On the Bacteria+Archaea dataset, the results of the original version of finding the furthest point to the last centroid was:

| k   | WCSS    | BIC     |
| --- | ------- | ------- |
| 2   | 1758.90 | 1953.61 |
| 3   | 1378.52 | 1670.57 |
| 4   | 1178.36 | 1567.76 |
| 5   | 1003.15 | 1489.90 |
| 6   | 860.60  | 1444.71 |

And now with the k-means++:

| k   | WCSS    | BIC     |
| --- | ------- | ------- |
| 2   | 1758.90 | 1953.61 |
| 3   | 1378.52 | 1670.57 |
| 4   | 1175.87 | 1565.27 |
| 5   | 981.33  | 1468.08 |
| 6   | 858.63  | 1442.73 |